### PR TITLE
add support to include yaml files in stack manifest

### DIFF
--- a/k8s_app_abstraction/models/stack.py
+++ b/k8s_app_abstraction/models/stack.py
@@ -21,7 +21,7 @@ from k8s_app_abstraction.models.pod_controllers import (
     StatefulsetList,
 )
 from k8s_app_abstraction.models.resource import Resource, ResourceList
-from k8s_app_abstraction.utils import dict_to_yaml, parse_yaml
+from k8s_app_abstraction.utils import dict_to_yaml, load_yaml_files, parse_yaml
 
 
 class Stack(Base, YamlMixin):
@@ -40,6 +40,10 @@ class Stack(Base, YamlMixin):
     @classmethod
     def new(cls, name: str, definition: str) -> "Stack":
         return Stack(name=name, **parse_yaml(definition))
+
+    @classmethod
+    def from_files(cls, *args: str) -> "Stack":
+        definition = load_yaml_files(*args)
 
     @property
     def chart(self):

--- a/k8s_app_abstraction/utils.py
+++ b/k8s_app_abstraction/utils.py
@@ -1,7 +1,17 @@
 import os
 from re import sub
+from urllib.parse import urlparse
 
+import requests
 import yaml
+
+
+def uri_validator(x):
+    try:
+        result = urlparse(x)
+        return all([result.scheme, result.netloc])
+    except Exception:
+        return False
 
 
 def merge(dict1, dict2):
@@ -44,6 +54,9 @@ def parse_yaml(content):
 
 def load_yaml_files(*args):
     def load_yaml_file(filepath) -> str:
+        if uri_validator(filepath):
+            return requests.get(filepath).content
+
         with open(filepath) as f:
             return f.read()
 

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -1,0 +1,66 @@
+from io import StringIO
+from textwrap import dedent
+from unittest import mock
+
+import pytest
+
+from k8s_app_abstraction.models.stack import Stack
+
+DEFINITION = dedent(
+    """
+    include:
+      - /etc/company/base.yml
+      - ~/user.yml
+
+    deployments:
+      app:
+        image: awesome/app
+        replicas: 3
+    """
+)
+
+BASE_YAML = """
+include:
+- /etc/company/databases.yml
+
+deployments:
+  foo:
+    image: bar
+"""
+
+DATABASES_YAML = """
+statefulsets:
+  redis:
+    image: redis:latest
+  postgres:
+    image: postgres:latest
+"""
+
+USER_YAML = """
+deployments:
+  pypi-cache:
+    image: my-pypi
+"""
+
+
+MOCKED_FILES = {
+    "/etc/company/base.yml": BASE_YAML,
+    "/etc/company/databases.yml": DATABASES_YAML,
+    "~/user.yml": USER_YAML,
+}
+
+
+def test_include_fine_not_found():
+    with pytest.raises(FileNotFoundError) as err:
+        Stack.new(name="test", definition=DEFINITION)
+
+
+def test_include():
+    def mock_open(name, *args, **kwargs):
+        if name not in MOCKED_FILES:
+            return open(name, *args, **kwargs)
+
+        return StringIO(MOCKED_FILES[name])
+
+    with mock.patch("k8s_app_abstraction.utils.open", new=mock_open):
+        stack = Stack.new(name="test", definition=DEFINITION)

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -3,25 +3,25 @@ from textwrap import dedent
 from unittest import mock
 
 import pytest
+import requests
 
 from k8s_app_abstraction.models.stack import Stack
 
-DEFINITION = dedent(
-    """
-    include:
-      - /etc/company/base.yml
-      - ~/user.yml
+DEFINITION = """
+include:
+  - /etc/company/base.yml
+  - ~/user.yml
 
-    deployments:
-      app:
-        image: awesome/app
-        replicas: 3
-    """
-)
+deployments:
+  app:
+    image: awesome/app
+    replicas: 3
+"""
 
 BASE_YAML = """
 include:
 - /etc/company/databases.yml
+- https://dev.inter.net//something-amazing/manifest.yml
 
 deployments:
   foo:
@@ -42,11 +42,20 @@ deployments:
     image: my-pypi
 """
 
+WEB_YAML = """
+deployments:
+  other-app:
+    image: other-app
+"""
 
 MOCKED_FILES = {
     "/etc/company/base.yml": BASE_YAML,
     "/etc/company/databases.yml": DATABASES_YAML,
     "~/user.yml": USER_YAML,
+}
+
+MOCKED_URLS = {
+    "https://dev.inter.net//something-amazing/manifest.yml": WEB_YAML,
 }
 
 
@@ -62,5 +71,34 @@ def test_include():
 
         return StringIO(MOCKED_FILES[name])
 
+    def mock_requests_get(url, *args, **kwargs):
+        if url not in MOCKED_URLS:
+            return requests.get(url, *args, **kwargs)
+
+        class FakeResponse:
+            content = MOCKED_URLS[url]
+
+        return FakeResponse()
+
     with mock.patch("k8s_app_abstraction.utils.open", new=mock_open):
-        stack = Stack.new(name="test", definition=DEFINITION)
+        with mock.patch(
+            "k8s_app_abstraction.utils.requests.get", new=mock_requests_get
+        ):
+            stack = Stack.new(name="test", definition=DEFINITION)
+            resources = {
+                f"{r.__class__.__name__}/{r.name}": r for r in stack.get_all_resources
+            }
+
+            # FROM top level yaml
+            assert "Deployment/app" in resources
+
+            # FROM top level include
+            assert "Deployment/foo" in resources
+            assert "Deployment/pypi-cache" in resources
+
+            # FROM nested includes
+            assert "Statefulset/redis" in resources
+            assert "Statefulset/postgres" in resources
+
+            # From URL
+            assert "Deployment/other-app" in resources


### PR DESCRIPTION
Added support to include yaml manifests for files and urls.

Example yaml with includes:

```yaml
# manifest.yml
include:
- https://dev.myorg.com/manifests/databases.yml
- ~/.user-overrides.yml

deployments:
  foo:
    image: bar
```